### PR TITLE
feat: add LogHandler option

### DIFF
--- a/endure.go
+++ b/endure.go
@@ -43,16 +43,11 @@ func New(level slog.Leveler, options ...Options) *Endure {
 		level = slog.LevelDebug
 	}
 
-	opts := &slog.HandlerOptions{
-		Level: level,
-	}
-
 	c := &Endure{
 		registar:    registar.New(),
 		graph:       graph.New(),
 		mu:          sync.RWMutex{},
 		stopTimeout: time.Second * 30,
-		log:         slog.New(slog.NewJSONHandler(os.Stderr, opts)),
 	}
 
 	// Main thread channels
@@ -62,6 +57,14 @@ func New(level slog.Leveler, options ...Options) *Endure {
 	// append options
 	for _, option := range options {
 		option(c)
+	}
+
+	// create default logger if not already defined in the provided options
+	if c.log == nil {
+		opts := &slog.HandlerOptions{
+			Level: level,
+		}
+		c.log = slog.New(slog.NewJSONHandler(os.Stderr, opts))
 	}
 
 	// start profiler server

--- a/options.go
+++ b/options.go
@@ -1,6 +1,10 @@
 package endure
 
-import "time"
+import (
+	"time"
+
+	"golang.org/x/exp/slog"
+)
 
 // GracefulShutdownTimeout sets the timeout to kill the vertices is one or more of them are frozen
 func GracefulShutdownTimeout(to time.Duration) Options {
@@ -18,5 +22,17 @@ func Visualize() Options {
 func EnableProfiler() Options {
 	return func(endure *Endure) {
 		endure.profiler = true
+	}
+}
+
+// LogHandler defines the logger handler to create the slog.Logger
+//
+// For example:
+//
+//	container = endure.New(slog.LevelInfo, LogHandler(slog.NewTextHandler(
+//	 os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+func LogHandler(handler slog.Handler) Options {
+	return func(endure *Endure) {
+		endure.log = slog.New(handler)
 	}
 }


### PR DESCRIPTION
# Reason for This PR

This PR add a LogHandler option that could be used to define the logger handler to create the slog.Logger.

For example:

container = endure.New(slog.LevelInfo, LogHandler(slog.NewTextHandler(
	 os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))

In this way we could use handler adapters that use zerolog or zap loggers.

## Description of Changes

Add LogHandler option. Additionally, the New signature could be modified to move the Level to an option, but did not want to change the contract.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
