### PR TITLE
chore: incorrect error usage in the logs

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -2,6 +2,7 @@ github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.etcd.io/gofail v0.1.0 h1:XItAMIhOojXFQMgrxjnd2EIIHun/d5qL0Pf7FzVTkFg=

--- a/poller.go
+++ b/poller.go
@@ -12,7 +12,7 @@ func (e *Endure) poll(r *result) {
 				continue
 			}
 			// log error message
-			e.log.Error("plugin returned an error from the Serve method", err, slog.String("plugin", res.vertexID))
+			e.log.Error("plugin returned an error from the 'Serve' method", slog.Any("error", err), slog.String("plugin", res.vertexID))
 			// set the error
 			res.err = err
 			// send handleErrorCh signal

--- a/stop.go
+++ b/stop.go
@@ -53,7 +53,7 @@ func (e *Endure) stop() error {
 
 			ret := stopMethod.Func.Call(inVals)[0].Interface()
 			if ret != nil {
-				e.log.Error("failed to stop the plugin", slog.String("error", ret.(error).Error()))
+				e.log.Error("failed to stop the plugin", slog.Any("error", ret.(error)))
 				mu.Lock()
 				errs = append(errs, ret.(error))
 				mu.Unlock()


### PR DESCRIPTION
# Reason for This PR

```
"msg":"plugin returned an error from the Serve ","!BADKEY":"/roadrunner-temporal/plugin.go:196: github.com/temporalio/roadrunner-temporal/v4.(*Plugin).Serve.func1: temporal_plugin_serve: error during reset: &errors.Error{Op:\"workflow_definition_init\", Kind:0xc8, Err:(*errors.Error)(0xc000964aa0), Raised:\"2024-06-04T14:39:28+02:00\", stack:errors.stack{callers:[]uintptr{0x105de9488, 0x105df2fd0, 0x105df33ec, 0x105df0034, 0x105df1b98, 0x105ea643c, 0x105ea6508, 0x105eacca4, 0x105eab58c, 0x104fe0954}}}, event: process exited, pid: 16762","plugin":"*rrtemporal.Plugin"
```

## Description of Changes

- Use `slog.Any` for the errors.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error logging to provide more detailed and accurate error messages during plugin operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->